### PR TITLE
docs: add uv install PATH note and run-key format explanation

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -40,6 +40,16 @@ crewplane --help
 
 The install succeeded when `crewplane --help` prints command help.
 
+> `uv tool install` places the executable in `~/.local/bin`. If `crewplane --help`
+> prints "command not found" immediately after installing, either open a new shell
+> session or add `~/.local/bin` to your `PATH`:
+>
+> ```bash
+> export PATH="$HOME/.local/bin:$PATH"
+> ```
+> Adding the export line to your shell profile (`~/.bashrc` or `~/.zshrc`) makes it
+> permanent.
+
 ## Install With pipx
 
 Use `pipx` if you prefer Python CLI tools in isolated environments:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -96,7 +96,18 @@ The run should start with:
 Mock invoker active: no provider CLI commands will be started.
 ```
 
-It should also print a console `Run Summary` with `Run ID` and `Status: succeeded`.
+It should also print a console `Run Summary` with `Run ID` and `Status: succeeded`,
+like this:
+
+```text
+Run Summary
+  Workflow: Single Agent Review
+  Run ID: 20260629-202539
+  Status: succeeded
+  Elapsed: 5.3s
+  Nodes: pending=0 running=0 succeeded=1 blocked=0 failed=0
+```
+
 The `Stages:` and `Results:` lines point to run-specific directories:
 
 - `.crewplane/execution-stages/<run-key>/` for runtime stage files
@@ -139,6 +150,12 @@ Example output:
 In that example, the run key is
 `single-agent-review--5e34bc54c79a-20260629-202539`. Use that value wherever
 the docs show `<run-key>`.
+
+Run keys always follow the format
+`<workflow-name>--<short-id>-<YYYYMMDD>-<HHMMSS>`, where the embedded timestamp
+tells you when the run started. The short id is a stable fingerprint of the
+workflow and project, so repeated runs of the same workflow share the same
+prefix and differ only by date and time.
 
 Then list everything that was written:
 


### PR DESCRIPTION
Followed the First Project Path in `docs/index.md` as a fresh install (issue #2) and ran `crewplane init`, `validate`, and `run` end to end in a new project. Everything worked as documented; two small friction points came up along the way.

**What changed**

1. **uv install PATH** — `uv tool install` places the executable in `~/.local/bin`, which may not be on `PATH` yet in the same shell session. Added a note with the export command and a pointer to the shell profile.
2. **Run-key format** — the quickstart example used a June-dated run key without explaining how keys are built. Added an explicit `<workflow-name>--<short-id>-<YYYYMMDD>-<HHMMSS>` format explanation and a realistic Run Summary example output taken from an actual mock run.

Verified against Crewplane v0.1.10 (installed via `uv tool install` on Linux).

## Summary

Docs-only changes: `docs/getting-started/installation.md` (+10 lines, PATH note) and `docs/getting-started/quickstart.md` (+18 lines, run-key format + example output). No behavior changes.

## Checklist

- [x] I ran the relevant tests locally
- [x] I updated docs if behavior changed